### PR TITLE
added gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.py linguist-language=Python
+static/* linguist-vendored


### PR DESCRIPTION
It was a bit confusing seeing CSS as main repo language, at a first glance it looks like another CSS template whereas core of this library is written in **Python**. I guess it would be more clearly to users who wants to use and contribute to see python as main language of this repo.
I used [linguist](https://github.com/github/linguist) package to improve your lib.